### PR TITLE
Two fixes/improvements:

### DIFF
--- a/archiver/redis.go
+++ b/archiver/redis.go
@@ -175,7 +175,6 @@ func (rd *RedisAdapter) NextNArchItems(queueKey string, n int64) ([]queueRecord,
 		return []queueRecord{}, fmt.Errorf("failed to get items from queue: %w", err)
 	}
 	items, err := lrangeCmd.Result()
-	fmt.Println("ITEMS: ", items)
 	if err != nil {
 		return []queueRecord{}, fmt.Errorf("failed to get items from queue: %w", err)
 	}

--- a/cncdb/dummydb.go
+++ b/cncdb/dummydb.go
@@ -58,8 +58,8 @@ func (dsql *DummySQL) GetArchSizesByYears(forceLoad bool) ([][2]int, error) {
 	return [][2]int{}, nil
 }
 
-func (dsql *DummySQL) GetSubcorpusName(subcID string) (string, error) {
-	return "", nil
+func (dsql *DummySQL) GetSubcorpusProps(subcID string) (SubcProps, error) {
+	return SubcProps{}, nil
 }
 
 func (dsql *DummySQL) GetAllUsersWithQueryHistory() ([]int, error) {

--- a/cncdb/mysqldr.go
+++ b/cncdb/mysqldr.go
@@ -69,8 +69,8 @@ func (ops *MySQLDryRun) GetArchSizesByYears(forceLoad bool) ([][2]int, error) {
 	return ops.db.GetArchSizesByYears(forceLoad)
 }
 
-func (ops *MySQLDryRun) GetSubcorpusName(subcID string) (string, error) {
-	return ops.db.GetSubcorpusName(subcID)
+func (ops *MySQLDryRun) GetSubcorpusProps(subcID string) (SubcProps, error) {
+	return ops.db.GetSubcorpusProps(subcID)
 }
 
 func (ops *MySQLDryRun) GetAllUsersWithQueryHistory() ([]int, error) {

--- a/cncdb/mysqli.go
+++ b/cncdb/mysqli.go
@@ -18,6 +18,11 @@ package cncdb
 
 import "time"
 
+type SubcProps struct {
+	Name      string
+	TextTypes map[string][]string
+}
+
 // IMySQLOps is an abstract interface for high level
 // database operations. We need it mainly to allow
 // injecting "dummy" database adapter for "dry-run" mode.
@@ -37,11 +42,11 @@ type IMySQLOps interface {
 	// Returns list of pairs where FIRST item is always YEAR, the SECOND one is COUNT
 	GetArchSizesByYears(forceLoad bool) ([][2]int, error)
 
-	// GetSubcorpusName takes a subcorpus "hash" ID and returns
+	// GetSubcorpusProps takes a subcorpus "hash" ID and returns
 	// a corresponding name defined by the author.
 	// The method should accept empty value by responding
 	// with empty value (and without error).
-	GetSubcorpusName(subcID string) (string, error)
+	GetSubcorpusProps(subcID string) (SubcProps, error)
 
 	GetAllUsersWithQueryHistory() ([]int, error)
 

--- a/cncdb/queryrec.go
+++ b/cncdb/queryrec.go
@@ -154,6 +154,6 @@ func (qr *UntypedQueryRecord) GetSupertype() (QuerySupertype, error) {
 	return st, nil
 }
 
-func (qr *UntypedQueryRecord) GetSubcorpus(db IMySQLOps) (string, error) {
-	return db.GetSubcorpusName(qr.SubcorpusID)
+func (qr *UntypedQueryRecord) GetSubcorpus(db IMySQLOps) (SubcProps, error) {
+	return db.GetSubcorpusProps(qr.SubcorpusID)
 }

--- a/indexer/conversion.go
+++ b/indexer/conversion.go
@@ -67,7 +67,7 @@ func importConc(
 	if err := json.Unmarshal([]byte(hRec.Rec.Data), &form); err != nil {
 		return nil, err
 	}
-	subcName, err := rec.GetSubcorpus(db)
+	subcProps, err := rec.GetSubcorpus(db)
 	if err != nil {
 		return nil, fmt.Errorf("failed to convert rec. to doc.: %w", err)
 	}
@@ -77,7 +77,7 @@ func importConc(
 		Created:        time.Unix(hRec.Created, 0),
 		UserID:         hRec.UserID,
 		Corpora:        rec.Corpora,
-		Subcorpus:      subcName,
+		Subcorpus:      subcProps.Name,
 		QuerySupertype: stype,
 		RawQueries:     make([]cncdb.RawQuery, 0, len(form.LastopForm.CurrQueries)),
 	}
@@ -105,7 +105,21 @@ func importConc(
 	if ans.Structures == nil {
 		ans.Structures = make([]string, 0, len(form.LastopForm.SelectedTextTypes))
 	}
+	var tt map[string][]string
+	if len(subcProps.TextTypes) > 0 {
+		tt = subcProps.TextTypes
+
+	} else {
+		tt = make(map[string][]string)
+	}
 	for attr, items := range form.LastopForm.SelectedTextTypes {
+		tmp, ok := tt[attr]
+		if !ok {
+			tmp = make([]string, 0, 10)
+		}
+		tt[attr] = append(tmp, items...)
+	}
+	for attr, items := range tt {
 		_, ok := ans.StructAttrs[attr]
 		if !ok {
 			ans.StructAttrs[attr] = make([]string, 0, len(items))
@@ -131,7 +145,7 @@ func importWlist(
 		return nil, err
 	}
 
-	subcName, err := rec.GetSubcorpus(db)
+	subcProps, err := rec.GetSubcorpus(db)
 	if err != nil {
 		return nil, fmt.Errorf("failed to convert rec. to doc.: %w", err)
 	}
@@ -142,7 +156,7 @@ func importWlist(
 		Created:        time.Unix(hRec.Created, 0),
 		UserID:         hRec.UserID,
 		Corpora:        rec.Corpora,
-		Subcorpus:      subcName,
+		Subcorpus:      subcProps.Name,
 		RawQuery:       form.Form.WLPattern,
 		PosAttrNames:   []string{form.Form.WLAttr},
 		PFilterWords:   form.Form.PFilterWords,
@@ -163,19 +177,19 @@ func importKwords(
 	}
 
 	subcorpora := make([]string, 0, 2)
-	subcName1, err := rec.GetSubcorpus(db)
+	subcProps1, err := rec.GetSubcorpus(db)
 	if err != nil {
 		return nil, fmt.Errorf("failed to convert rec. to doc.: %w", err)
 	}
-	if subcName1 != "" {
-		subcorpora = append(subcorpora, subcName1)
+	if subcProps1.Name != "" {
+		subcorpora = append(subcorpora, subcProps1.Name)
 	}
-	subcName2, err := db.GetSubcorpusName(form.Form.RefUsesubcorp)
+	subcProps2, err := db.GetSubcorpusProps(form.Form.RefUsesubcorp)
 	if err != nil {
 		return nil, fmt.Errorf("failed to convert rec. to doc.: %w", err)
 	}
-	if subcName2 != "" {
-		subcorpora = append(subcorpora, subcName2)
+	if subcProps2.Name != "" {
+		subcorpora = append(subcorpora, subcProps2.Name)
 	}
 	corpora := append(rec.Corpora, form.Form.RefCorpname)
 
@@ -204,7 +218,7 @@ func importPquery(
 	if err := json.Unmarshal([]byte(hRec.Rec.Data), &form); err != nil {
 		return nil, err
 	}
-	subcName, err := rec.GetSubcorpus(db)
+	subcProps, err := rec.GetSubcorpus(db)
 	if err != nil {
 		return nil, fmt.Errorf("failed to convert rec. to doc.: %w", err)
 	}
@@ -262,7 +276,7 @@ func importPquery(
 		Created:        time.Unix(hRec.Created, 0),
 		UserID:         hRec.UserID,
 		Corpora:        rec.Corpora,
-		Subcorpus:      subcName,
+		Subcorpus:      subcProps.Name,
 		QuerySupertype: stype,
 		RawQueries:     mergedRawQueries,
 		PosAttrs:       mergedPosAttrs,

--- a/indexer/documents/mappings.go
+++ b/indexer/documents/mappings.go
@@ -1,3 +1,20 @@
+// Copyright 2024 Martin Zimandl <martin.zimandl@gmail.com>
+// Copyright 2024 Tomas Machalek <tomas.machalek@gmail.com>
+// Copyright 2024 Institute of the Czech National Corpus,
+//                Faculty of Arts, Charles University
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package documents
 
 import (

--- a/indexer/indexer.go
+++ b/indexer/indexer.go
@@ -25,6 +25,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"os"
+	"strings"
 	"time"
 
 	"github.com/blevesearch/bleve/v2"
@@ -189,7 +190,13 @@ func (idx *Indexer) Search(terms []searchedTerm, limit int, order []string, fiel
 			return nil, fmt.Errorf("unexpected query object requirement: \"%s\"", term.Requirement)
 		}
 		if term.IsWildcard {
-			wc := bleve.NewWildcardQuery("*" + term.Value + "*")
+			// Note: here we have to convert the query to lower case manually
+			// as it appears Bleve does not use respective mapping filter and
+			// our fields use 'kontext_query_analyzer' which applies lowercase
+			// conversion. Also note that this may cause problem in some edge
+			// cases as the filter's algorithm is not the same as used
+			// in strings.ToLower
+			wc := bleve.NewWildcardQuery("*" + strings.ToLower(term.Value) + "*")
 			wc.SetField(term.Field)
 			addQueryFn(wc)
 

--- a/indexer/source.go
+++ b/indexer/source.go
@@ -59,6 +59,6 @@ func (qr *unspecifiedQueryRecord) GetSupertype() (cncdb.QuerySupertype, error) {
 	return st, nil
 }
 
-func (qr *unspecifiedQueryRecord) GetSubcorpus(db cncdb.IMySQLOps) (string, error) {
-	return db.GetSubcorpusName(qr.SubcorpusID)
+func (qr *unspecifiedQueryRecord) GetSubcorpusProps(db cncdb.IMySQLOps) (cncdb.SubcProps, error) {
+	return db.GetSubcorpusProps(qr.SubcorpusID)
 }


### PR DESCRIPTION
1) in the "wildcard" mode, apparently we have to convert queries to lowercase
   manually as a respective token filter is not applied to the query
  (Bleve?!)
2) extract concrete text types out of a named subcorpus
   (TODO - still missing 'within' variant)