### PR TITLE
Add support for the "slow query" flag

### DIFF
--- a/cncdb/queryrec.go
+++ b/cncdb/queryrec.go
@@ -67,6 +67,8 @@ type concForm struct {
 	// CurrParsedQueries encodes KonText's TypeScript type:
 	// {[k:string]:Array<[Array<[string|Array<string>, string]>, boolean]>};
 	CurrParsedQueries map[string][]any `json:"curr_parsed_queries"`
+
+	TreatAsSlowQuery bool `json:"treat_as_slow_query"`
 }
 
 type wlistForm struct {

--- a/cncdb/types_test.go
+++ b/cncdb/types_test.go
@@ -1,0 +1,49 @@
+// Copyright 2024 Tomas Machalek <tomas.machalek@gmail.com>
+// Copyright 2024 Institute of the Czech National Corpus,
+//                Faculty of Arts, Charles University
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package cncdb
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+var src = "{\"user_id\":2,\"q\":[\"q[(lemma=\\\"voda\\\" | sublemma=\\\"voda\\\" | word=\\\"voda\\\")]\"],\"corpora\":[\"syn2020\"],\"usesubcorp\":null,\"lines_groups\":{\"data\":[],\"sorted\":false},\"lastop_form\":{\"form_type\":\"query\",\"curr_query_types\":{\"syn2020\":\"simple\"},\"curr_queries\":{\"syn2020\":\"voda\"},\"curr_parsed_queries\":{\"syn2020\":[[[[[\"lemma\",\"sublemma\",\"word\"],\"voda\"]],false]]},\"curr_pcq_pos_neg_values\":{\"syn2020\":\"pos\"},\"curr_include_empty_values\":{\"syn2020\":false},\"curr_lpos_values\":{\"syn2020\":null},\"curr_qmcase_values\":{\"syn2020\":true},\"curr_default_attr_values\":{\"syn2020\":\"\"},\"curr_use_regexp_values\":{\"syn2020\":true},\"asnc\":true,\"no_query_history\":false,\"shuffle\":true,\"fc_lemword_type\":\"all\",\"fc_lemword_wsize\":[-5,5],\"fc_lemword\":\"\",\"fc_pos_type\":\"all\",\"fc_pos_wsize\":[-5,5],\"fc_pos\":[],\"selected_text_types\":{},\"bib_mapping\":{},\"cutoff\":0,\"treat_as_slow_query\":true,\"alt_corpus\":null},\"id\":\"hQiqOwq8AycE\",\"prev_id\": \"xxx\", \"persist_level\":1}"
+
+func TestGeneralDataRecordAttrAccess(t *testing.T) {
+	var rec GeneralDataRecord
+
+	err := json.Unmarshal([]byte(src), &rec)
+	assert.NoError(t, err)
+	assert.Equal(t, []string{"q[(lemma=\"voda\" | sublemma=\"voda\" | word=\"voda\")]"}, rec.GetQuery())
+	assert.Equal(t, true, rec.IsFlaggedAsSlow())
+	assert.Equal(t, []string{"syn2020"}, rec.GetCorpora())
+	assert.Equal(t, "xxx", rec.GetPrevID())
+}
+
+func TestGeneralDataRecordRemoveSlowFlag(t *testing.T) {
+	var rec GeneralDataRecord
+
+	err := json.Unmarshal([]byte(src), &rec)
+	assert.NoError(t, err)
+	rec.RemoveSlowFlag()
+	assert.Equal(t, false, rec.IsFlaggedAsSlow())
+	newJSON, _ := json.Marshal(rec)
+	assert.False(t, strings.Contains(string(newJSON), "\"treat_as_slow_query\""))
+}

--- a/indexer/source.go
+++ b/indexer/source.go
@@ -20,7 +20,10 @@ package indexer
 import (
 	"camus/cncdb"
 	"fmt"
+	"reflect"
 	"time"
+
+	"github.com/rs/zerolog/log"
 )
 
 // unspecifiedQueryRecord represents any query record as saved by
@@ -36,6 +39,21 @@ type unspecifiedQueryRecord struct {
 	SubcorpusID string         `json:"usesubcorp"`
 	LastopForm  map[string]any `json:"lastop_form"`
 	Form        map[string]any `json:"form"`
+}
+
+func (qr *unspecifiedQueryRecord) IsFlaggedAsSlow() bool {
+	v, ok := qr.Form["treat_as_slow_query"]
+	if !ok {
+		return false
+	}
+	typedVal, ok := v.(bool)
+	if !ok {
+		log.Warn().
+			Str("type", reflect.TypeOf(v).String()).
+			Msg("found conc query form entry treat_as_slow_query but with wrong type")
+		return false
+	}
+	return typedVal
 }
 
 // GetSupertype extracts query type (supertype in terms used by KonText sources) info.

--- a/kcache/meter.go
+++ b/kcache/meter.go
@@ -20,6 +20,7 @@ type statsRecord struct {
 	SubcorpusSize int64   `json:"subcorpusSize,omitempty"`
 	TimeProc      float64 `json:"timeProc"`
 	Query         string  `json:"query"`
+	FlaggedAsSlow bool    `json:"flaggedAsSlow"`
 }
 
 // -----------------------
@@ -145,6 +146,7 @@ func (meter *Meter) listenForData() {
 					SubcorpusSize: item.SubcorpusSize,
 					TimeProc:      rec.ProcTime(),
 					Query:         qChain[0],
+					FlaggedAsSlow: item.FlaggedAsSlow,
 				}
 				if err := meter.writeStats(sr); err != nil {
 					log.Error().Err(err).Str("concId", item.ID()).Msg("failed to write stats data")

--- a/reporting/common.go
+++ b/reporting/common.go
@@ -21,10 +21,11 @@ import (
 )
 
 type OpStats struct {
-	NumErrors   int `json:"numErrors"`
-	NumMerged   int `json:"numMerged"`
-	NumInserted int `json:"numInserted"`
-	NumFetched  int `json:"numFetched"`
+	NumErrors      int `json:"numErrors"`
+	NumMerged      int `json:"numMerged"`
+	NumInserted    int `json:"numInserted"`
+	NumFetched     int `json:"numFetched"`
+	NumFlaggedSlow int `json:"numFlaggedSlow"`
 }
 
 func (bgs *OpStats) UpdateBy(other OpStats) {

--- a/reporting/reporting.go
+++ b/reporting/reporting.go
@@ -33,6 +33,7 @@ create table camus_operations_stats (
   num_errors int,
   num_merged int,
   num_inserted int,
+  num_flagged_slow int,
   index_size int
 );
 
@@ -98,6 +99,7 @@ func (ds *StatusWriter) WriteOperationsStatus(item OpStats) {
 			Int("num_merged", item.NumMerged).
 			Int("num_errors", item.NumErrors).
 			Int("num_fetched", item.NumFetched).
+			Int("num_flagged_slow", item.NumFlaggedSlow).
 			Int("num_inserted", item.NumInserted)
 	}
 }


### PR DESCRIPTION
i.e. Camus is able to read it from a conc. query record, add it to the stats and remove it before archiving